### PR TITLE
Simplify TA anal

### DIFF
--- a/EMGratioCode.m
+++ b/EMGratioCode.m
@@ -1,0 +1,123 @@
+% Code to compute TA ratios
+clear; clc;
+
+%% Switch
+saveswitch=0;
+
+%% Load files
+[fn, pn] = uigetfile('Go get your KINEMATIC analysis file (AnalENCO)') ;
+load([pn fn],'meanABSError', 'BASELINE2end','CHAMPend');
+
+[fn, pn] = uigetfile(pn,'Go get your TA analysis file (AnalRBITA)') ;
+load([pn fn]);
+
+[fn, pn] = uigetfile(pn,'Go get your GroupDataCONS_F file') ;
+load([pn fn]);
+
+load([pn 'SyncData.mat']);
+load([pn 'CyclesCritiques.mat']);
+
+
+if sum(isnan(BASELINE2end))>0
+    nsujets=find(isnan(BASELINE2end),1,'first')-1;
+else
+    nsujets=30;
+end
+
+for isujet=nsujets:-1:1
+    %% Get the baseline cycles used for kinematic Analyses with valid EMG and compute baseline template
+    baselinecycles=find(not(isnan(meanABSError.baseline2(BASELINE2end(isujet)-49:BASELINE2end(isujet),isujet)))...
+        & not(isnan(AnalTA.TA.baseline2(1,BASELINE2end(isujet)-49:BASELINE2end(isujet),isujet)))');
+    baselinecycles=baselinecycles+BASELINE2end(isujet)-50;
+    baselinelateTA(:,isujet)=mean(AnalTA.TA.baseline2(:,baselinecycles,isujet),2);
+    
+    %% Get mean TA activity for the valid cycles during Fearly and late
+    FFearlycycles=find(not(isnan(AnalTA.TA.CHAMP(1,2:11,isujet)))'...
+        & not(isnan(meanABSError.CHAMP(2:11,isujet))));
+    FFearlycycles=FFearlycycles+1;
+    FFearlyTA(:,isujet)=mean(AnalTA.TA.CHAMP(:,FFearlycycles,isujet),2);
+    
+    FFlatecycles=find(not(isnan(AnalTA.TA.CHAMP(1,CHAMPend(isujet)-49:CHAMPend(isujet),isujet)))'...
+        & not(isnan(meanABSError.CHAMP(CHAMPend(isujet)-49:CHAMPend(isujet),isujet))));
+    FFlatecycles=FFlatecycles+CHAMPend(isujet)-50;
+    FFlateTA(:,isujet)=mean(AnalTA.TA.CHAMP(:,FFlatecycles,isujet),2);
+    
+    %% Compute TA ratio and log transformed TA ratio
+    FFearlyratio(:,isujet)=FFearlyTA(:,isujet)./baselinelateTA(:,isujet);
+    FFlateratio(:,isujet)=FFlateTA(:,isujet)./baselinelateTA(:,isujet);
+    
+    log2FFearlyratio(:,isujet)=log2(FFearlyratio(:,isujet));
+    log2FFlateratio(:,isujet)=log2(FFlateratio(:,isujet));
+    
+    %% Synchronise CONS_F signal with TA  and interpolate on 1300 sample
+    k=POST1(isujet)-FF1(isujet);
+    for j=POST1(isujet)-1:-1:FF1(isujet)
+        if GroupData.Cycle_Table(3,j,isujet)==1 & SyncTiming(isujet,j)<1000 & SyncTiming(isujet,j)>500
+            
+            stop=find(isnan(GroupData.CONS_F(:,j,isujet))==0,1,'last')+4;
+            
+            if stop>0;
+                x=SyncTiming(isujet,j)-round(AnalTA.dureeswing.CHAMP(k,isujet)*0.3):stop;
+                y=GroupData.CONS_F(x,j,isujet)';
+                CONS_F(:,k,isujet)=interp1(1:length(x),y,1:(length(x)-1)/1299:length(x));
+            end
+            %% Find Peak Force Timing (PFC) for each stride
+            peakCONS_Ftiming(k,isujet)=round(find(CONS_F(:,k,isujet)==min(CONS_F(:,k,isujet)),1,'first'));
+            
+        else
+            CONS_F(:,k,isujet)=nan;
+            peakCONS_Ftiming(k,isujet)=nan;
+        end
+        
+        k=k-1;
+    end
+    
+    %% Find averaged PFC during early and late adaptation
+    peakCONS_FtimingFFearly(isujet)=round(mean(peakCONS_Ftiming(FFearlycycles,isujet),1));
+    peakCONS_FtimingFFlate(isujet)=round(mean(peakCONS_Ftiming(FFlatecycles,isujet),1));
+    
+    %% Compute Total TAratio, TAratio BeforePFC and TAratio AfterPFC and their log2 transform
+    BeforePFCEarly(isujet)=mean(FFearlyratio(1:peakCONS_FtimingFFearly(isujet),isujet),1);
+    log2BeforePFCEarly(isujet)=mean(log2FFearlyratio(1:peakCONS_FtimingFFearly(isujet),isujet),1);
+    BeforePFCLate(isujet)=mean(FFlateratio(1:peakCONS_FtimingFFlate(isujet),isujet),1);
+    log2BeforePFCLate(isujet)=mean(log2FFlateratio(1:peakCONS_FtimingFFlate(isujet),isujet),1);
+    
+    AfterPFCEarly(isujet)=mean(FFearlyratio(peakCONS_FtimingFFearly(isujet):end,isujet),1);
+    log2AfterPFCEarly(isujet)=mean(log2FFearlyratio(peakCONS_FtimingFFearly(isujet):end,isujet),1);
+    AfterPFCLate(isujet)=mean(FFlateratio(peakCONS_FtimingFFlate(isujet):end,isujet),1);
+    log2AfterPFCLate(isujet)=mean(log2FFlateratio(peakCONS_FtimingFFlate(isujet):end,isujet),1);
+    
+    TotalEarly(isujet)=mean(FFearlyratio(:,isujet),1);
+    log2TotalEarly(isujet)=mean(log2FFearlyratio(:,isujet),1);
+    TotalLate(isujet)=mean(FFlateratio(:,isujet),1);
+    log2TotalLate(isujet)=mean(log2FFlateratio(:,isujet),1);
+    
+    
+    
+end
+
+TAratiovariable.peakCONS_FtimingFFearly=peakCONS_FtimingFFearly;
+TAratiovariable.peakCONS_FtimingFFlate=peakCONS_FtimingFFlate;
+TAratiovariable.BeforePFCEarly=BeforePFCEarly;
+TAratiovariable.log2BeforePFCEarly=log2BeforePFCEarly;
+TAratiovariable.BeforePFCLate=BeforePFCLate;
+TAratiovariable.log2BeforePFCLate=log2BeforePFCLate;
+TAratiovariable.AfterPFCEarly=AfterPFCEarly;
+TAratiovariable.log2AfterPFCEarly=log2AfterPFCEarly;
+TAratiovariable.AfterPFCLate=AfterPFCLate;
+TAratiovariable.log2AfterPFCLate=log2AfterPFCLate;
+TAratiovariable.TotalEarly=TotalEarly;
+TAratiovariable.log2TotalEarly=log2TotalEarly;
+TAratiovariable.TotalLate=TotalLate;
+TAratiovariable.log2TotalLate=log2TotalLate;
+TAratiovariable.FFearlyratio=FFearlyratio;
+TAratiovariable.log2FFearlyratio=log2FFearlyratio;
+TAratiovariable.FFlateratio=FFlateratio;
+TAratiovariable.log2FFlateratio=log2FFlateratio;
+
+if saveswitch==1
+[fn, pn]=uiputfile('Save your variables');
+save([pn fn],'TAratiovariable');
+end
+
+clearvars -except TAratiovariable 

--- a/GUI_jason/EMGratioCode.m
+++ b/GUI_jason/EMGratioCode.m
@@ -1,18 +1,13 @@
-% Code to compute TA ratios
-clear; clc;
+function [ TAratiovariable ] = EMGratioCode( GroupData,AnalTA,path )
+%EMGratioCode Is used to compute EMGratio as in Bouffard et al. 2016 Neural
+%Plasticity during force field adaptation. Inputs include the Force Command
+%Signal synchronised on Heelstrike and the RBIAnalTA signal synchronised on
+%the middle of the ENCO signal during pushoff.
 
-%% Switch
-saveswitch=0;
 
 %% Load files
-[fn, pn] = uigetfile('Go get your KINEMATIC analysis file (AnalENCO)') ;
+[fn, pn] = uigetfile(path, 'Go get your KINEMATIC analysis file (AnalENCO)') ;
 load([pn fn],'meanABSError', 'BASELINE2end','CHAMPend');
-
-[fn, pn] = uigetfile(pn,'Go get your TA analysis file (AnalRBITA)') ;
-load([pn fn]);
-
-[fn, pn] = uigetfile(pn,'Go get your GroupDataCONS_F file') ;
-load([pn fn]);
 
 load([pn 'SyncData.mat']);
 load([pn 'CyclesCritiques.mat']);
@@ -114,10 +109,10 @@ TAratiovariable.FFearlyratio=FFearlyratio;
 TAratiovariable.log2FFearlyratio=log2FFearlyratio;
 TAratiovariable.FFlateratio=FFlateratio;
 TAratiovariable.log2FFlateratio=log2FFlateratio;
+TAratiovariable.baselinelateTA=baselinelateTA;
+TAratiovariable.FFearlyTA=FFearlyTA;
+TAratiovariable.FFlateTA=FFlateTA;
 
-if saveswitch==1
-[fn, pn]=uiputfile('Save your variables');
-save([pn fn],'TAratiovariable');
+
 end
 
-clearvars -except TAratiovariable 

--- a/GUI_jason/EMGratioCode.m~
+++ b/GUI_jason/EMGratioCode.m~
@@ -1,0 +1,118 @@
+function [ TAratiovariable ] = EMGratioCode( GroupData,AnalTA,path )
+%EMGratioCode Is used to compute EMGratio as in Bouffard et al. 2016 Neural
+%Plasticity during force field adaptation. Inputs include the Force Command
+%Signal synchronised on Heelstrike and the RBIAnalTA signal synchronised on
+%the middle of the ENCO signal during pushoff.
+
+
+%% Load files
+[fn, pn] = uigetfile(path, 'Go get your KINEMATIC analysis file (AnalENCO)') ;
+load([pn fn],'meanABSError', 'BASELINE2end','CHAMPend');
+
+load([pn 'SyncData.mat']);
+load([pn 'CyclesCritiques.mat']);
+
+
+if sum(isnan(BASELINE2end))>0
+    nsujets=find(isnan(BASELINE2end),1,'first')-1;
+else
+    nsujets=30;
+end
+
+for isujet=nsujets:-1:1
+    %% Get the baseline cycles used for kinematic Analyses with valid EMG and compute baseline template
+    baselinecycles=find(not(isnan(meanABSError.baseline2(BASELINE2end(isujet)-49:BASELINE2end(isujet),isujet)))...
+        & not(isnan(AnalTA.TA.baseline2(1,BASELINE2end(isujet)-49:BASELINE2end(isujet),isujet)))');
+    baselinecycles=baselinecycles+BASELINE2end(isujet)-50;
+    baselinelateTA(:,isujet)=mean(AnalTA.TA.baseline2(:,baselinecycles,isujet),2);
+    
+    %% Get mean TA activity for the valid cycles during Fearly and late
+    FFearlycycles=find(not(isnan(AnalTA.TA.CHAMP(1,2:11,isujet)))'...
+        & not(isnan(meanABSError.CHAMP(2:11,isujet))));
+    FFearlycycles=FFearlycycles+1;
+    FFearlyTA(:,isujet)=mean(AnalTA.TA.CHAMP(:,FFearlycycles,isujet),2);
+    
+    FFlatecycles=find(not(isnan(AnalTA.TA.CHAMP(1,CHAMPend(isujet)-49:CHAMPend(isujet),isujet)))'...
+        & not(isnan(meanABSError.CHAMP(CHAMPend(isujet)-49:CHAMPend(isujet),isujet))));
+    FFlatecycles=FFlatecycles+CHAMPend(isujet)-50;
+    FFlateTA(:,isujet)=mean(AnalTA.TA.CHAMP(:,FFlatecycles,isujet),2);
+    
+    %% Compute TA ratio and log transformed TA ratio
+    FFearlyratio(:,isujet)=FFearlyTA(:,isujet)./baselinelateTA(:,isujet);
+    FFlateratio(:,isujet)=FFlateTA(:,isujet)./baselinelateTA(:,isujet);
+    
+    log2FFearlyratio(:,isujet)=log2(FFearlyratio(:,isujet));
+    log2FFlateratio(:,isujet)=log2(FFlateratio(:,isujet));
+    
+    %% Synchronise CONS_F signal with TA  and interpolate on 1300 sample
+    k=POST1(isujet)-FF1(isujet);
+    for j=POST1(isujet)-1:-1:FF1(isujet)
+        if GroupData.Cycle_Table(3,j,isujet)==1 & SyncTiming(isujet,j)<1000 & SyncTiming(isujet,j)>500
+            
+            stop=find(isnan(GroupData.CONS_F(:,j,isujet))==0,1,'last')+4;
+            
+            if stop>0;
+                x=SyncTiming(isujet,j)-round(AnalTA.dureeswing.CHAMP(k,isujet)*0.3):stop;
+                y=GroupData.CONS_F(x,j,isujet)';
+                CONS_F(:,k,isujet)=interp1(1:length(x),y,1:(length(x)-1)/1299:length(x));
+            end
+            %% Find Peak Force Timing (PFC) for each stride
+            peakCONS_Ftiming(k,isujet)=round(find(CONS_F(:,k,isujet)==min(CONS_F(:,k,isujet)),1,'first'));
+            
+        else
+            CONS_F(:,k,isujet)=nan;
+            peakCONS_Ftiming(k,isujet)=nan;
+        end
+        
+        k=k-1;
+    end
+    
+    %% Find averaged PFC during early and late adaptation
+    peakCONS_FtimingFFearly(isujet)=round(mean(peakCONS_Ftiming(FFearlycycles,isujet),1));
+    peakCONS_FtimingFFlate(isujet)=round(mean(peakCONS_Ftiming(FFlatecycles,isujet),1));
+    
+    %% Compute Total TAratio, TAratio BeforePFC and TAratio AfterPFC and their log2 transform
+    BeforePFCEarly(isujet)=mean(FFearlyratio(1:peakCONS_FtimingFFearly(isujet),isujet),1);
+    log2BeforePFCEarly(isujet)=mean(log2FFearlyratio(1:peakCONS_FtimingFFearly(isujet),isujet),1);
+    BeforePFCLate(isujet)=mean(FFlateratio(1:peakCONS_FtimingFFlate(isujet),isujet),1);
+    log2BeforePFCLate(isujet)=mean(log2FFlateratio(1:peakCONS_FtimingFFlate(isujet),isujet),1);
+    
+    AfterPFCEarly(isujet)=mean(FFearlyratio(peakCONS_FtimingFFearly(isujet):end,isujet),1);
+    log2AfterPFCEarly(isujet)=mean(log2FFearlyratio(peakCONS_FtimingFFearly(isujet):end,isujet),1);
+    AfterPFCLate(isujet)=mean(FFlateratio(peakCONS_FtimingFFlate(isujet):end,isujet),1);
+    log2AfterPFCLate(isujet)=mean(log2FFlateratio(peakCONS_FtimingFFlate(isujet):end,isujet),1);
+    
+    TotalEarly(isujet)=mean(FFearlyratio(:,isujet),1);
+    log2TotalEarly(isujet)=mean(log2FFearlyratio(:,isujet),1);
+    TotalLate(isujet)=mean(FFlateratio(:,isujet),1);
+    log2TotalLate(isujet)=mean(log2FFlateratio(:,isujet),1);
+    
+    
+    
+end
+
+TAratiovariable.peakCONS_FtimingFFearly=peakCONS_FtimingFFearly;
+TAratiovariable.peakCONS_FtimingFFlate=peakCONS_FtimingFFlate;
+TAratiovariable.BeforePFCEarly=BeforePFCEarly;
+TAratiovariable.log2BeforePFCEarly=log2BeforePFCEarly;
+TAratiovariable.BeforePFCLate=BeforePFCLate;
+TAratiovariable.log2BeforePFCLate=log2BeforePFCLate;
+TAratiovariable.AfterPFCEarly=AfterPFCEarly;
+TAratiovariable.log2AfterPFCEarly=log2AfterPFCEarly;
+TAratiovariable.AfterPFCLate=AfterPFCLate;
+TAratiovariable.log2AfterPFCLate=log2AfterPFCLate;
+TAratiovariable.TotalEarly=TotalEarly;
+TAratiovariable.log2TotalEarly=log2TotalEarly;
+TAratiovariable.TotalLate=TotalLate;
+TAratiovariable.log2TotalLate=log2TotalLate;
+TAratiovariable.FFearlyratio=FFearlyratio;
+TAratiovariable.log2FFearlyratio=log2FFearlyratio;
+TAratiovariable.FFlateratio=FFlateratio;
+TAratiovariable.log2FFlateratio=log2FFlateratio;
+TAratiovariable.baselinelateTA=baselinelateTA;
+TAratiovariable.FFearlyTA=FFearlyTA;
+TAratiovariable.FFlateTA=FFlateTA;
+
+
+end
+

--- a/GUI_jason/Filter_RBI.m
+++ b/GUI_jason/Filter_RBI.m
@@ -1,35 +1,27 @@
 
-function FilterRBI
-[fn,pn]=uigetfile('*.mat','select the calibration file');
-load([pn,fn],'-mat');
+function fdata = FilterRBI(data,windowlength,type,dim)
+% This function do a Rectified bin averaging filtering of EMG data
+%Inputs: data: 2d or 3d Data tables
+% window length: Length of the rbi window
+%type: 1=vector; 2= matrixè 3= 3D matrix
+%dim: dimension of the table corresponding to time
 
-[fn,pn]=uigetfile('*.mat','select the data file');
-load([pn,fn],'-mat');
+dimension=size(data);
 
-lenght=size(data(:,:),2);
-
-Signal=input('Quel signal voulez-vous filtrer? ');
-
-%Détermine le numéro de table du signal d'intérêt à partir du fichier
-%de calibration
-s=['numSignal=find(strcmp(chan_name(1,:),',char(39),Signal,char(39),')==1);'];eval(s);
-clear s
-
-
-for i=5:lenght-4
+if type == 3
     
-    s=['fdata(:,i-4)=mean(abs(data(',num2str(numSignal),',i-4:i+4)),2);'];eval(s);
-        
+fdata(1:dimension(1),1:dimension(2),1:dimension(3))=nan;
+
+    if dim == 1
+       
+        for itime=ceil(windowlength/2):dimension(1)-ceil(windowlength/2)
+            fdata(itime,:,:)=mean(data(itime-ceil(windowlength/2):itime+ceil(windowlength/2),:,:),1);
+        end
+    end
+    
 end
 
-%----------------%
-% Enregistrer
-%----------------%
-cd(pn); %On va dans le repertoire du sujet traité
-
-% Enregistrement des données
-[outfn,outpn]=uiputfile([fn]);
-save([outpn,outfn],'data','fdata','Signal');
+ 
 
 
 

--- a/GUI_jason/Filter_RBI.m
+++ b/GUI_jason/Filter_RBI.m
@@ -7,6 +7,7 @@ function fdata = FilterRBI(data,windowlength,type,dim)
 %dim: dimension of the table corresponding to time
 
 dimension=size(data);
+data=abs(data);
 
 if type == 3
     
@@ -15,7 +16,7 @@ fdata(1:dimension(1),1:dimension(2),1:dimension(3))=nan;
     if dim == 1
        
         for itime=ceil(windowlength/2):dimension(1)-ceil(windowlength/2)
-            fdata(itime,:,:)=mean(data(itime-ceil(windowlength/2):itime+ceil(windowlength/2),:,:),1);
+            fdata(itime,:,:)=mean(data(itime-floor(windowlength/2):itime+floor(windowlength/2),:,:),1);
         end
     end
     

--- a/GUI_jason/Filter_RBI.m~
+++ b/GUI_jason/Filter_RBI.m~
@@ -1,0 +1,40 @@
+
+function fdata = FilterRBI(data,windowlength,type,dim)
+% This function do a Rectified bin averaging filtering of EMG data
+%Inputs: data: 2d or 3d Data tables
+% window length: Length of the rbi window
+%type: 1=vector; 2= matrixè 3= 3D matrix
+%dim: dimension of the table corresponding to time
+
+dimension=size(data);
+
+if type == 3
+    
+fdata(1:dimension(1),1:dimension(2),1:dimension(3))=nan;
+
+    if dim == 1
+        
+        fdata(1:floor(windowlength/2),:,:)=mean(data(1:windowlength,:,:),dim);
+        fdata(dureecycle-floor(windowlength/2):dureecycle,:,:)=mean(data(1:windowlength,:,:),dim);
+
+    
+clear s
+
+
+for i=5:lenght-4
+    
+    s=['fdata(:,i-4)=mean(abs(data(',num2str(numSignal),',i-4:i+4)),2);'];eval(s);
+        
+end
+
+%----------------%
+% Enregistrer
+%----------------%
+cd(pn); %On va dans le repertoire du sujet traité
+
+% Enregistrement des données
+[outfn,outpn]=uiputfile([fn]);
+save([outpn,outfn],'data','fdata','Signal');
+
+
+

--- a/GUI_jason/GUI_analysis_JB.m
+++ b/GUI_jason/GUI_analysis_JB.m
@@ -561,7 +561,7 @@ function TAAnal_TimeNorm_Callback(hObject, eventdata, handles)
 [fn,pn]=uigetfile('*.mat','Choisi ton fichier de données de groupe');
 load([pn,fn],'-mat');
 
-side=menu('Do you want to Analyse right or left TA?','Right','Left');
+side=menu('Do you want to Analyse right or left TA?','Right (RTA)','Left (LTA)','Just TA (TA)');
 if side==1
     data=Filter_RBI(GroupData.RTA,9,3,1);
     
@@ -569,16 +569,23 @@ elseif side==2
     
     data=Filter_RBI(GroupData.LTA,9,3,1);
     
+elseif side==3
+    
+    data=Filter_RBI(GroupData.TA,9,3,1);
+    
 end
 
-[AnalTA]=RBITAvariablesgeneratorTimenorm(GroupData.Cycle_Table,data)
+[AnalTA]=RBITAvariablesgeneratorTimenorm(GroupData.Cycle_Table,data,pn)
 
-clear GroupData
-
-[pathname]=uigetdir('Sélectionne le dossier où tu désires sauvegarder ton fichier AnalRBI');
-save([pathname, 'AnalRBITA'], 'AnalTA'); 
+save([pn, 'AnalRBITA.mat'], 'AnalTA'); 
 
 disp('AnalRBITA saved')
+
+TAratiovariable = EMGratioCode(GroupData,AnalTA, pn);
+
+save([pn, 'TAratio.mat'], 'TAratiovariable'); 
+
+disp('TAratio saved')
 
 
 % --------------------------------------------------------------------

--- a/GUI_jason/GUI_analysis_JB.m~
+++ b/GUI_jason/GUI_analysis_JB.m~
@@ -571,14 +571,14 @@ elseif side==2
     
 end
 
-[AnalTA]=RBITAvariablesgeneratorTimenorm(GroupData.Cycle_Table,data)
+[AnalTA]=AvariablesgeneratorTimenorm(GroupData.Cycle_Table,data)
 
 clear GroupData
 
-[pathname]=uigetdir('Sélectionne le dossier où tu désires sauvegarder ton fichier AnalRBI');
-save([pathname, 'AnalRBITA'], 'AnalTA'); 
+[pathname]=uiputfile('Sélectionne le dossier où tu désires sauvegarder ton fichier AnalRBI');
+save(filename,'AnalTA'); 
 
-disp('AnalRBITA saved')
+disp('AnalTA saved')
 
 
 % --------------------------------------------------------------------

--- a/GUI_jason/GUI_analysis_JB.m~
+++ b/GUI_jason/GUI_analysis_JB.m~
@@ -571,14 +571,14 @@ elseif side==2
     
 end
 
-[AnalTA]=AvariablesgeneratorTimenorm(GroupData.Cycle_Table,data)
+[AnalTA]=RBITAvariablesgeneratorTimenorm(GroupData.Cycle_Table,data)
 
-clear GroupData
+[pathname]=uigetdir('Sélectionne le dossier où tu désires sauvegarder ton fichier AnalRBI');
+save([pathname, 'AnalRBITA'], 'AnalTA'); 
 
-[pathname]=uiputfile('Sélectionne le dossier où tu désires sauvegarder ton fichier AnalRBI');
-save(filename,'AnalTA'); 
+disp('AnalRBITA saved')
 
-disp('AnalTA saved')
+TAratiovariable = EMGratioCode(GroupData.CONS_F,AnalTA);
 
 
 % --------------------------------------------------------------------

--- a/GUI_jason/RBITAvariablesgeneratorTimenorm.m
+++ b/GUI_jason/RBITAvariablesgeneratorTimenorm.m
@@ -1,5 +1,5 @@
 
-function [AnalTA]= TAvariablesgenerator(Cycle_Table,data)
+function [AnalTA]= TAvariablesgenerator(Cycle_Table,data,path)
 %% Baseline 2 TA enligné %MODIFICATION 30% au lieur de 20% du swing lignes 15:17, 50, 71, 170, 263
 
 n=find(isnan(Cycle_Table(1,1,:))==1);
@@ -9,8 +9,8 @@ else
     n=30
 end
 
-load('SyncData.mat');
-load('CyclesCritiques.mat');
+load([path, 'SyncData.mat']);
+load([path 'CyclesCritiques.mat']);
 
 AnalTA.TA.baseline2(1:1300,1:588,1:30)=nan;
 AnalTA.TA.CHAMP(1:1300,1:397,1:30)=nan;


### PR DESCRIPTION
Tout devrait fonctionner maintenant en lançant l’onglet GroupData/
TAAnal_TimeNorm dans le GUI. Pour que le script fonctionne vous aurez
besoin d’avoir complété l’analyse cinématique (donc généré AnalENCO,
SyncData, CyclesCritiques) et d’avoir au minimum intégrer les canaux
{‘ENCO’, ‘TA’, ‘CONS_F’} dans votre fichier GroupData. Le programme
sauvegardera un fichier AnalRBITA.mat et TAratio.mat dans le dossier où
vous avez sélectionné votre fichier GroupData.