### PR TITLE
Bug fixed

### DIFF
--- a/GUI_jason/SyncPushoff.m
+++ b/GUI_jason/SyncPushoff.m
@@ -66,9 +66,12 @@ function [SyncTiming, SyncThreshold] = SyncPushoff(Cycle_Table,data)
                 temp=find((data(500:end-1,j,i)<SyncThreshold(i))&(diff(data(500:end,j,i))<0));
                 if not(isempty(temp))
                     SyncTiming(i,j)=temp(1)+499;
-                    
+                else
+                    SyncTiming(i,j)=0;
                 end
                 
+            else
+                    SyncTiming(i,j)=0;
             end
             
         end


### PR DESCRIPTION
If the conditions are not met for cycle j of subject i, replace
SyncTiming(j,i) by 0. Before, the code was just ignoring it, so the
program crashed if the last cycles were not good